### PR TITLE
Remove duplicate `params` & `context` args

### DIFF
--- a/src/prompt/functions/ai-extract-function.ts
+++ b/src/prompt/functions/ai-extract-function.ts
@@ -16,7 +16,6 @@ export function createAIExtractFunction<Schema extends z.ZodObject<any>>(
     maxRetries = 0,
     systemMessage,
     params,
-    context,
     functionCallConcurrency,
   }: {
     /** The ChatModel used to make API calls. */
@@ -33,8 +32,6 @@ export function createAIExtractFunction<Schema extends z.ZodObject<any>>(
     systemMessage?: string;
     /** Model params to use for each API call (optional). */
     params?: Prompt.Runner.ModelParams;
-    /** Optional context to pass to ChatModel.run calls */
-    context?: Model.Ctx;
     /** The number of function calls to make concurrently. */
     functionCallConcurrency?: number;
   },
@@ -65,7 +62,6 @@ export function createAIExtractFunction<Schema extends z.ZodObject<any>>(
   const runner = createAIRunner({
     chatModel,
     systemMessage,
-    context,
     functions: [extractFunction],
     mode: 'functions',
     maxIterations: maxRetries + 1,

--- a/src/prompt/functions/ai-extract-function.ts
+++ b/src/prompt/functions/ai-extract-function.ts
@@ -57,8 +57,12 @@ export function createAIExtractFunction<Schema extends z.ZodObject<any>>(
   // Create a runner that will call the function, validate the args and retry
   // if necessary, and return the result.
   const runner = createAIRunner({
-    chatModel: chatModel.addParams({
-      function_call: { name },
+    chatModel: chatModel.clone({
+      params: {
+        // @TODO: use deep partial on clone/extend input
+        model: chatModel.getParams().model,
+        function_call: { name },
+      },
     }),
     systemMessage,
     functions: [extractFunction],

--- a/src/prompt/functions/ai-extract-function.ts
+++ b/src/prompt/functions/ai-extract-function.ts
@@ -15,7 +15,6 @@ export function createAIExtractFunction<Schema extends z.ZodObject<any>>(
     schema,
     maxRetries = 0,
     systemMessage,
-    params,
     functionCallConcurrency,
   }: {
     /** The ChatModel used to make API calls. */
@@ -30,8 +29,6 @@ export function createAIExtractFunction<Schema extends z.ZodObject<any>>(
     maxRetries?: number;
     /** Add a system message to the beginning of the messages array. */
     systemMessage?: string;
-    /** Model params to use for each API call (optional). */
-    params?: Prompt.Runner.ModelParams;
     /** The number of function calls to make concurrently. */
     functionCallConcurrency?: number;
   },
@@ -60,16 +57,14 @@ export function createAIExtractFunction<Schema extends z.ZodObject<any>>(
   // Create a runner that will call the function, validate the args and retry
   // if necessary, and return the result.
   const runner = createAIRunner({
-    chatModel,
+    chatModel: chatModel.addParams({
+      function_call: { name },
+    }),
     systemMessage,
     functions: [extractFunction],
     mode: 'functions',
     maxIterations: maxRetries + 1,
     functionCallConcurrency,
-    params: {
-      ...params,
-      function_call: { name },
-    },
     shouldBreakLoop: (message) => Msg.isFuncResult(message),
     validateContent: (content) => {
       return extractFunction.parseArgs(content || '');

--- a/src/prompt/functions/ai-runner.ts
+++ b/src/prompt/functions/ai-runner.ts
@@ -28,8 +28,6 @@ export function createAIRunner<Content extends any = string>(args: {
   systemMessage?: string;
   /** Model params to use for each API call (optional). */
   params?: Prompt.Runner.ModelParams;
-  /** Optional context to pass to ChatModel.run calls */
-  context?: Model.Ctx;
 }): Prompt.Runner<Content> {
   /** Return the content string or an empty string if null. */
   function defaultValidateContent(content: string | null): Content {
@@ -51,15 +49,9 @@ export function createAIRunner<Content extends any = string>(args: {
       functionCallConcurrency,
       systemMessage,
       params: runnerModelParams,
-      context: runnerContext,
       validateContent = defaultValidateContent,
       shouldBreakLoop = defaultShouldBreakLoop,
     } = args;
-
-    const mergedContext = {
-      ...runnerContext,
-      ...context,
-    };
 
     // Add the functions/tools to the model params
     const additonalParams = getParams({ functions, mode });
@@ -90,7 +82,7 @@ export function createAIRunner<Content extends any = string>(args: {
           ...additonalParams,
           messages,
         };
-        const { message } = await chatModel.run(runParams, mergedContext);
+        const { message } = await chatModel.run(runParams, context);
         messages.push(message);
 
         // Run functions from tool/function call messages and append the new messages

--- a/src/prompt/functions/ai-runner.ts
+++ b/src/prompt/functions/ai-runner.ts
@@ -26,8 +26,6 @@ export function createAIRunner<Content extends any = string>(args: {
   mode?: Prompt.Runner.Mode;
   /** Add a system message to the beginning of the messages array. */
   systemMessage?: string;
-  /** Model params to use for each API call (optional). */
-  params?: Prompt.Runner.ModelParams;
 }): Prompt.Runner<Content> {
   /** Return the content string or an empty string if null. */
   function defaultValidateContent(content: string | null): Content {
@@ -48,7 +46,6 @@ export function createAIRunner<Content extends any = string>(args: {
       maxIterations = 5,
       functionCallConcurrency,
       systemMessage,
-      params: runnerModelParams,
       validateContent = defaultValidateContent,
       shouldBreakLoop = defaultShouldBreakLoop,
     } = args;
@@ -77,7 +74,6 @@ export function createAIRunner<Content extends any = string>(args: {
       try {
         // Run the model with the current messages and functions/tools
         const runParams = {
-          ...runnerModelParams,
           ...modelParams,
           ...additonalParams,
           messages,


### PR DESCRIPTION
These are both already handled statefully by the `ChatModel` so we shouldn't be 
introducing a second way to accomplish the same thing and more arguments to 
support it.

- Remove duplicate context arg
- Remove duplicate `params` argument
