### PR TITLE
Make Model and Datastore immutable

### DIFF
--- a/src/datastore/pinecone/datastore.ts
+++ b/src/datastore/pinecone/datastore.ts
@@ -1,4 +1,4 @@
-import { mergeEvents } from '../../utils/helpers.js';
+import { deepMerge, mergeEvents } from '../../utils/helpers.js';
 import { AbstractDatastore } from '../datastore.js';
 import type { Datastore, Prettify } from '../types.js';
 import type { PineconeClient } from './client.js';
@@ -168,10 +168,10 @@ export class PineconeDatastore<
       embeddingModel: this.embeddingModel,
       cacheKey: this.cacheKey,
       cache: this.cache,
-      context: this.context,
       debug: this.debug,
       pinecone: this.pinecone,
       ...args,
+      context: deepMerge(this.context, args?.context),
       events: mergeEvents(this.events, args?.events),
     }) as unknown as this;
   }

--- a/src/datastore/pinecone/hybrid-datastore.ts
+++ b/src/datastore/pinecone/hybrid-datastore.ts
@@ -1,4 +1,4 @@
-import { mergeEvents } from '../../utils/helpers.js';
+import { deepMerge, mergeEvents } from '../../utils/helpers.js';
 import type { Model } from '../../model/index.js';
 import { AbstractHybridDatastore } from '../hybrid-datastore.js';
 import type { Datastore, Prettify } from '../types.js';
@@ -191,11 +191,11 @@ export class PineconeHybridDatastore<
       embeddingModel: this.embeddingModel,
       cacheKey: this.cacheKey,
       cache: this.cache,
-      context: this.context,
       debug: this.debug,
       pinecone: this.pinecone,
       spladeModel: this.spladeModel,
       ...args,
+      context: deepMerge(this.context, args?.context),
       events: mergeEvents(this.events, args?.events),
     }) as unknown as this;
   }

--- a/src/model/chat.test.ts
+++ b/src/model/chat.test.ts
@@ -90,26 +90,26 @@ describe('ChatModel', () => {
     });
   });
 
-  it('implements clone', async () => {
+  it('implements extend', async () => {
     const chatModel = new ChatModel({
       client: Client,
       context: { userId: '123' },
       params: { model: 'gpt-fake' },
       events: { onApiResponse: [() => {}] },
     });
-    const clonedModel = chatModel.clone({
+    const clonedModel = chatModel.extend({
       context: { cloned: true },
       params: { model: 'gpt-fake-cloned' },
       events: { onApiResponse: [() => {}] },
     });
-    expect(clonedModel.getContext()).toEqual({
+    expect(clonedModel.context).toEqual({
       userId: '123',
       cloned: true,
     });
-    expect(clonedModel.getParams()).toEqual({
+    expect(clonedModel.params).toEqual({
       model: 'gpt-fake-cloned',
     });
-    expect(clonedModel.getEvents()?.onApiResponse?.length).toBe(2);
+    expect(clonedModel.events.onApiResponse?.length).toBe(2);
   });
 
   it('can cache responses', async () => {

--- a/src/model/chat.ts
+++ b/src/model/chat.ts
@@ -211,9 +211,15 @@ export class ChatModel extends AbstractModel<
       client: this.client,
       debug: this.debug,
       ...args,
-      context: deepMerge(this.context, args?.context),
       params: deepMerge(this.params, args?.params),
-      events: mergeEvents(this.events, args?.events),
+      context:
+        args?.context && Object.keys(args.context).length === 0
+          ? undefined
+          : deepMerge(this.context, args?.context),
+      events:
+        args?.events && Object.keys(args.events).length === 0
+          ? undefined
+          : mergeEvents(this.events, args?.events),
     }) as unknown as this;
   }
 }

--- a/src/model/chat.ts
+++ b/src/model/chat.ts
@@ -1,10 +1,11 @@
+import type { PartialDeep } from 'type-fest';
 import type { SetOptional } from 'type-fest';
 import type { ModelArgs } from './model.js';
 import type { Model } from './types.js';
 import { calculateCost } from './utils/calculate-cost.js';
 import { createOpenAIClient } from './clients/openai.js';
 import { AbstractModel } from './model.js';
-import { deepMerge } from '../utils/helpers.js';
+import { deepMerge, mergeEvents, type Prettify } from '../utils/helpers.js';
 
 export type ChatModelArgs = SetOptional<
   ModelArgs<
@@ -14,6 +15,11 @@ export type ChatModelArgs = SetOptional<
     Model.Chat.Response
   >,
   'client' | 'params'
+>;
+
+export type PartialChatModelArgs = Prettify<
+  PartialDeep<Pick<ChatModelArgs, 'params'>> &
+    Partial<Omit<ChatModelArgs, 'params'>>
 >;
 
 export class ChatModel extends AbstractModel<
@@ -26,19 +32,32 @@ export class ChatModel extends AbstractModel<
   modelType = 'chat' as const;
   modelProvider = 'openai' as const;
 
-  constructor(args?: ChatModelArgs) {
-    let { client, params, ...rest } = args ?? {};
-    // Add a default client if none is provided
-    client = client ?? createOpenAIClient();
-    // Set default model if no params are provided
-    params = params ?? { model: 'gpt-3.5-turbo' };
-    super({ client, params, ...rest });
-    if (args?.debug) {
-      this.addEvents({
-        onStart: [logInput],
-        onComplete: [logResponse],
-      });
-    }
+  constructor(args: ChatModelArgs = {}) {
+    const {
+      // Add a default client if none is provided
+      client = createOpenAIClient(),
+      // Set default model if no params are provided
+      params = { model: 'gpt-3.5-turbo' },
+      debug,
+      events,
+      ...rest
+    } = args;
+
+    super({
+      client,
+      params,
+      debug,
+      events: mergeEvents(
+        events,
+        debug
+          ? {
+              onStart: [logInput],
+              onComplete: [logResponse],
+            }
+          : {}
+      ),
+      ...rest,
+    });
   }
 
   protected async runModel(
@@ -185,20 +204,17 @@ export class ChatModel extends AbstractModel<
   }
 
   /** Clone the model and merge/orverride the given properties. */
-  clone(args?: ChatModelArgs): this {
-    const { cacheKey, cache, client, context, debug, params, events } =
-      args ?? {};
-
-    // @ts-ignore
+  extend(args?: PartialChatModelArgs): this {
     return new ChatModel({
-      cacheKey: cacheKey ?? this.cacheKey,
-      cache: cache ?? this.cache,
-      client: client ?? this.client,
-      context: this.mergeContext(this.context, context),
-      debug: debug ?? this.debug,
-      params: this.mergeParams(this.params, params ?? {}),
-      events: this.mergeEvents(this.events, events || {}),
-    });
+      cacheKey: this.cacheKey,
+      cache: this.cache,
+      client: this.client,
+      debug: this.debug,
+      ...args,
+      context: deepMerge(this.context, args?.context),
+      params: deepMerge(this.params, args?.params),
+      events: mergeEvents(this.events, args?.events),
+    }) as unknown as this;
   }
 }
 

--- a/src/model/completion.ts
+++ b/src/model/completion.ts
@@ -1,9 +1,11 @@
+import type { PartialDeep } from 'type-fest';
 import type { SetOptional } from 'type-fest';
 import type { ModelArgs } from './model.js';
 import type { Model } from './types.js';
 import { calculateCost } from './utils/calculate-cost.js';
 import { createOpenAIClient } from './clients/openai.js';
 import { AbstractModel } from './model.js';
+import { deepMerge, mergeEvents, type Prettify } from '../index.js';
 
 export type CompletionModelArgs = SetOptional<
   ModelArgs<
@@ -13,6 +15,11 @@ export type CompletionModelArgs = SetOptional<
     Model.Completion.Response
   >,
   'client' | 'params'
+>;
+
+export type PartialCompletionModelArgs = Prettify<
+  PartialDeep<Pick<CompletionModelArgs, 'params'>> &
+    Partial<Omit<CompletionModelArgs, 'params'>>
 >;
 
 export class CompletionModel extends AbstractModel<
@@ -70,19 +77,16 @@ export class CompletionModel extends AbstractModel<
   }
 
   /** Clone the model and merge/orverride the given properties. */
-  clone(args?: CompletionModelArgs): this {
-    const { cacheKey, cache, client, context, debug, params, events } =
-      args ?? {};
-
-    // @ts-ignore
+  extend(args?: PartialCompletionModelArgs): this {
     return new CompletionModel({
-      cacheKey: cacheKey ?? this.cacheKey,
-      cache: cache ?? this.cache,
-      client: client ?? this.client,
-      context: this.mergeContext(this.context, context),
-      debug: debug ?? this.debug,
-      params: this.mergeParams(this.params, params ?? {}),
-      events: this.mergeEvents(this.events, events || {}),
-    });
+      cacheKey: this.cacheKey,
+      cache: this.cache,
+      client: this.client,
+      debug: this.debug,
+      ...args,
+      context: deepMerge(this.context, args?.context),
+      params: deepMerge(this.params, args?.params),
+      events: mergeEvents(this.events, args?.events),
+    }) as unknown as this;
   }
 }

--- a/src/model/embedding.test.ts
+++ b/src/model/embedding.test.ts
@@ -78,26 +78,26 @@ describe('EmbeddingModel', () => {
     });
   });
 
-  it('implements clone', async () => {
+  it('implements extend', async () => {
     const model = new EmbeddingModel({
       client: Client,
       context: { userId: '123' },
       params: { model: 'gpt-fake' },
       events: { onApiResponse: [() => {}] },
     });
-    const clonedModel = model.clone({
+    const clonedModel = model.extend({
       context: { cloned: true },
       params: { model: 'gpt-fake-cloned' },
       events: { onApiResponse: [() => {}] },
     });
-    expect(clonedModel.getContext()).toEqual({
+    expect(clonedModel.context).toEqual({
       userId: '123',
       cloned: true,
     });
-    expect(clonedModel.getParams()).toEqual({
+    expect(clonedModel.params).toEqual({
       model: 'gpt-fake-cloned',
     });
-    expect(clonedModel.getEvents()?.onApiResponse?.length).toBe(2);
+    expect(clonedModel.events.onApiResponse?.length).toBe(2);
   });
 
   it('can cache responses', async () => {

--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -25,7 +25,7 @@ class Test extends AbstractModel<
       cached: false,
     });
   }
-  clone() {
+  extend() {
     return this;
   }
 }
@@ -33,7 +33,7 @@ class Test extends AbstractModel<
 describe('AbstractModel', () => {
   it('can be instantiated', () => {
     const test = new Test({ params: { model: 'testmodel' }, client: false });
-    expect(test.getParams()).toEqual({
+    expect(test.params).toEqual({
       model: 'testmodel',
     });
   });

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -40,7 +40,7 @@ export type PartialModelArgs<
   MClient extends Model.Base.Client,
   MConfig extends Model.Base.Config,
   MRun extends Model.Base.Run,
-  MResponse extends Model.Base.Response
+  MResponse extends Model.Base.Response,
 > = Prettify<
   PartialDeep<Pick<ModelArgs<MClient, MConfig, MRun, MResponse>, 'params'>> &
     Partial<Omit<ModelArgs<MClient, MConfig, MRun, MResponse>, 'params'>>
@@ -61,7 +61,7 @@ export abstract class AbstractModel<
 
   /** Clones the model, optionally modifying its config */
   abstract extend<
-    Args extends PartialModelArgs<MClient, MConfig, MRun, MResponse>
+    Args extends PartialModelArgs<MClient, MConfig, MRun, MResponse>,
   >(args?: Args): this;
 
   public abstract readonly modelType: Model.Type;

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -1,6 +1,7 @@
+import type { PartialDeep } from 'type-fest';
 import { createTokenizer } from './utils/tokenizer.js';
 import type { Model } from './types.js';
-import { type Prettify, deepMerge } from '../utils/helpers.js';
+import { deepMerge, type Prettify } from '../utils/helpers.js';
 import {
   type CacheKey,
   type CacheStorage,
@@ -35,6 +36,16 @@ export interface ModelArgs<
   debug?: boolean;
 }
 
+export type PartialModelArgs<
+  MClient extends Model.Base.Client,
+  MConfig extends Model.Base.Config,
+  MRun extends Model.Base.Run,
+  MResponse extends Model.Base.Response
+> = Prettify<
+  PartialDeep<Pick<ModelArgs<MClient, MConfig, MRun, MResponse>, 'params'>> &
+    Partial<Omit<ModelArgs<MClient, MConfig, MRun, MResponse>, 'params'>>
+>;
+
 export abstract class AbstractModel<
   MClient extends Model.Base.Client,
   MConfig extends Model.Base.Config,
@@ -48,21 +59,22 @@ export abstract class AbstractModel<
     context: Model.Ctx
   ): Promise<MResponse>;
 
-  /** Clone the model, optionally adding new arguments */
-  abstract clone<Args extends ModelArgs<MClient, MConfig, MRun, MResponse>>(
-    args?: Args
-  ): this;
+  /** Clones the model, optionally modifying its config */
+  abstract extend<
+    Args extends PartialModelArgs<MClient, MConfig, MRun, MResponse>
+  >(args?: Args): this;
 
-  abstract modelType: Model.Type;
-  abstract modelProvider: Model.Provider;
-  protected cacheKey: CacheKey<MRun & MConfig, string>;
-  protected cache?: CacheStorage<string, MResponse>;
-  protected client: MClient;
-  protected context: Model.Ctx;
-  protected debug: boolean;
-  protected params: MConfig & Partial<MRun>;
-  protected events: Model.Events<MRun & MConfig, MResponse, AResponse>;
-  public tokenizer: Model.ITokenizer;
+  public abstract readonly modelType: Model.Type;
+  public abstract readonly modelProvider: Model.Provider;
+
+  protected readonly cacheKey: CacheKey<MRun & MConfig, string>;
+  protected readonly cache?: CacheStorage<string, MResponse>;
+  public readonly client: MClient;
+  public readonly context: Model.Ctx;
+  public readonly debug: boolean;
+  public readonly params: MConfig & Partial<MRun>;
+  public readonly events: Model.Events<MRun & MConfig, MResponse, AResponse>;
+  public readonly tokenizer: Model.ITokenizer;
 
   constructor(args: ModelArgs<MClient, MConfig, MRun, MResponse>) {
     this.cacheKey = args.cacheKey ?? defaultCacheKey;
@@ -80,8 +92,8 @@ export abstract class AbstractModel<
     context?: Model.Ctx
   ): Promise<MResponse> {
     const start = Date.now();
-    const mergedContext = this.mergeContext(this.context, context);
-    const mergedParams = deepMerge(this.params, params) as MRun & MConfig;
+    const mergedContext = deepMerge(this.context, context);
+    const mergedParams = deepMerge(this.params, params);
 
     await Promise.allSettled(
       this.events.onStart?.map((event) =>
@@ -168,103 +180,5 @@ export abstract class AbstractModel<
       );
       throw error;
     }
-  }
-
-  /** Set the cache to a new cache. Set to undefined to remove existing. */
-  setCache(cache: typeof this.cache | undefined): this {
-    this.cache = cache;
-    return this;
-  }
-
-  /** Get the current client */
-  getClient() {
-    return this.client;
-  }
-
-  /** Set the client to a new OpenAI API client. */
-  setClient(client: typeof this.client): this {
-    this.client = client;
-    return this;
-  }
-
-  /** Get the current context */
-  getContext() {
-    return this.context;
-  }
-
-  /** Add the context. Overrides existing keys. */
-  updateContext(context: typeof this.context): this {
-    this.context = this.mergeContext(this.context, context);
-    return this;
-  }
-
-  /** Set the context to a new context. Removes all existing values. */
-  setContext(context: Model.Ctx): this {
-    this.context = context;
-    return this;
-  }
-
-  /** Get the current params */
-  getParams() {
-    return this.params;
-  }
-
-  /** Add the params. Overrides existing keys. */
-  addParams(params: Partial<typeof this.params>): this {
-    const modelChanged = params.model && params.model !== this.params.model;
-    this.params = this.mergeParams(this.params, params);
-    if (modelChanged) {
-      this.tokenizer = createTokenizer(this.params.model);
-    }
-    return this;
-  }
-
-  /** Set the params to a new params. Removes all existing values. */
-  setParams(params: typeof this.params): this {
-    this.params = params;
-    this.tokenizer = createTokenizer(this.params.model);
-    return this;
-  }
-
-  /** Get the current event handlers */
-  getEvents() {
-    return this.events;
-  }
-
-  /** Add event handlers to the model. */
-  addEvents(events: typeof this.events): this {
-    this.events = this.mergeEvents(this.events, events);
-    return this;
-  }
-
-  /**
-   * Set the event handlers to a new set of events. Removes all existing event handlers.
-   * Set to empty object `{}` to remove all events.
-   */
-  setEvents(events: typeof this.events): this {
-    this.events = events;
-    return this;
-  }
-
-  protected mergeContext(
-    classContext: Model.Ctx,
-    newContext?: Model.Ctx
-  ): Model.Ctx {
-    if (!newContext) return classContext;
-    return deepMerge(classContext, newContext);
-  }
-
-  protected mergeParams(
-    classParams: Partial<typeof this.params>,
-    newParams: Partial<typeof this.params>
-  ): typeof this.params {
-    return deepMerge(classParams, newParams) as any;
-  }
-
-  protected mergeEvents(
-    existingEvents: typeof this.events,
-    newEvents: typeof this.events
-  ): typeof this.events {
-    return deepMerge(existingEvents, newEvents);
   }
 }

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -156,34 +156,34 @@ export namespace Model {
       timestamp: string;
       modelType: Type;
       modelProvider: Provider;
-      params: MParams;
-      context: Ctx;
+      params: Readonly<MParams>;
+      context: Readonly<Ctx>;
     }) => void | Promise<void>)[];
     onApiResponse?: ((event: {
       timestamp: string;
       modelType: Type;
       modelProvider: Provider;
-      params: MParams;
-      response: AResponse;
+      params: Readonly<MParams>;
+      response: Readonly<AResponse>;
       latency: number;
-      context: Ctx;
+      context: Readonly<Ctx>;
     }) => void | Promise<void>)[];
     onComplete?: ((event: {
       timestamp: string;
       modelType: Type;
       modelProvider: Provider;
-      params: MParams;
-      response: MResponse;
-      context: Ctx;
+      params: Readonly<MParams>;
+      response: Readonly<MResponse>;
+      context: Readonly<Ctx>;
       cached: boolean;
     }) => void | Promise<void>)[];
     onError?: ((event: {
       timestamp: string;
       modelType: Type;
       modelProvider: Provider;
-      params: MParams;
+      params: Readonly<MParams>;
       error: unknown;
-      context: Ctx;
+      context: Readonly<Ctx>;
     }) => void | Promise<void>)[];
   }
 

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -9,6 +9,7 @@ import type {
   EmbeddingResponse,
   OpenAIClient,
 } from 'openai-fetch';
+import type { ReadonlyDeep } from 'type-fest';
 import type { AbstractModel } from './model.js';
 import type { ChatModel } from './chat.js';
 import type { CompletionModel } from './completion.js';
@@ -108,7 +109,7 @@ export namespace Model {
   }
 
   /** Generic metadata object. */
-  export type Ctx = { [key: string]: any };
+  export type Ctx = ReadonlyDeep<{ [key: string]: any }>;
 
   /**
    * Embedding Model

--- a/src/prompt/functions/ai-extract-function.ts
+++ b/src/prompt/functions/ai-extract-function.ts
@@ -57,10 +57,8 @@ export function createAIExtractFunction<Schema extends z.ZodObject<any>>(
   // Create a runner that will call the function, validate the args and retry
   // if necessary, and return the result.
   const runner = createAIRunner({
-    chatModel: chatModel.clone({
+    chatModel: chatModel.extend({
       params: {
-        // @TODO: use deep partial on clone/extend input
-        model: chatModel.getParams().model,
         function_call: { name },
       },
     }),

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { deepMerge, mergeEvents } from './helpers.js';
+
+describe('utils.helpers', () => {
+  it('deepMerge', () => {
+    expect(deepMerge(undefined, {})).toEqual({});
+    expect(deepMerge({}, undefined)).toEqual({});
+    expect(deepMerge(undefined, undefined)).toEqual({});
+    expect(deepMerge({}, { foo: true })).toEqual({ foo: true });
+    // Ensure arrays are merged in a stable order
+    expect(deepMerge({ foo: [1, 2, 3] }, { foo: [4, 5, 6] })).toEqual({
+      foo: [1, 2, 3, 4, 5, 6],
+    });
+  });
+
+  it('mergeEvents', () => {
+    expect(mergeEvents(undefined, {})).toEqual({});
+    expect(mergeEvents({}, undefined)).toEqual({});
+    expect(mergeEvents(undefined, undefined)).toEqual({});
+    expect(mergeEvents({}, { foo: true })).toEqual({ foo: true });
+    // Ensure duplicates are removed from event arrays and ordering remains stable
+    expect(
+      mergeEvents({ foo: [1, 2, 2, 3] }, { foo: [0, 4, 3, 5, 2, 6] })
+    ).toEqual({
+      foo: [1, 2, 3, 0, 4, 5, 6],
+    });
+    expect(
+      mergeEvents(
+        { foo: [console.debug, console.log] },
+        { foo: [console.warn, console.debug, console.log] }
+      )
+    ).toEqual({
+      foo: [console.debug, console.log, console.warn],
+    });
+  });
+});

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -4,7 +4,46 @@ import { deepmerge as deepmergeInit } from '@fastify/deepmerge';
 export type Prettify<T> = { [K in keyof T]: T[K] } & {};
 
 type DeepMerge = ReturnType<typeof deepmergeInit>;
-export const deepMerge: DeepMerge = deepmergeInit();
+const deepMergeImpl: DeepMerge = deepmergeInit();
+const deepMergeEventsImpl: DeepMerge = deepmergeInit({
+  // Note: this is not using a recursive deep merge since it isn't used for events.
+  mergeArray: () => (a: any[], b: any[]) => stableDedupe([...a, ...b]),
+});
+
+// Slightly custom deepMerge which handles `undefined` arguments as empty objects.
+export function deepMerge<
+  T1 extends object | undefined | null,
+  T2 extends object | undefined | null
+>(t1?: T1, t2?: T2): T1 & T2 {
+  return deepMergeImpl<T1, T2>(
+    t1 ?? ({} as T1),
+    t2 ?? ({} as T2)
+  ) as unknown as any;
+}
+
+// Slightly custom deepMerge which handles `undefined` arguments as empty objects
+// and ensures that we remove duplicate event handlers.
+export function mergeEvents<
+  T1 extends object | undefined,
+  T2 extends object | undefined
+>(t1?: T1, t2?: T2): T1 & T2 {
+  return deepMergeEventsImpl<T1, T2>(
+    t1 ?? ({} as T1),
+    t2 ?? ({} as T2)
+  ) as unknown as any;
+}
+
+/** Dedupes the given array maintaining a stable order in the output array. */
+function stableDedupe(input: any[]) {
+  const seen = new Set();
+  return input.filter((value) => {
+    if (seen.has(value)) {
+      return false;
+    }
+    seen.add(value);
+    return true;
+  });
+}
 
 /**
  * From `obj`, create a new object that does not include `keys`.

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -13,7 +13,7 @@ const deepMergeEventsImpl: DeepMerge = deepmergeInit({
 // Slightly custom deepMerge which handles `undefined` arguments as empty objects.
 export function deepMerge<
   T1 extends object | undefined | null,
-  T2 extends object | undefined | null
+  T2 extends object | undefined | null,
 >(t1?: T1, t2?: T2): T1 & T2 {
   return deepMergeImpl<T1, T2>(
     t1 ?? ({} as T1),
@@ -25,7 +25,7 @@ export function deepMerge<
 // and ensures that we remove duplicate event handlers.
 export function mergeEvents<
   T1 extends object | undefined,
-  T2 extends object | undefined
+  T2 extends object | undefined,
 >(t1?: T1, t2?: T2): T1 & T2 {
   return deepMergeEventsImpl<T1, T2>(
     t1 ?? ({} as T1),


### PR DESCRIPTION
- make model and datastore immutable
- remove previous accessors in favor of readonly public properties
- fix a bug that previously existed if you cloned an existing model with `debug: true`, it would add the debug events twice; now all event handlers get deduped while retaining a stable ordering
- `AbstractModel.extend` and `Datastore.extend` now support the old `clone` functionality as well as modifying any params
- the types were a bit tricky in several places, but overall I'm happy with where it ended up

@rileytomasek one note: the reason I had to remove the class methods for `merge*` was because we're now calling some of these in the constructor of subclasses before `super` is called, so the previous method which was nicer for typing no longer worked. I tried a few diff variations but ended up using what I think is a much cleaner replacement for `deepMerge` and `mergeEvents`, which is a slight variation on the underlying package to cleanly handle `undefined` parameters as empty objects. Also added unit tests for these changes.

One downside to this approach is that it's difficult to reset events/params/context to an empty object, but I don't think this is too important since the user can still override individual fields on these objects to be `undefined`.

TODO: add unit tests which verify immutability after `.extend()`.