### PR TITLE
Fix datastore to rely on same path to embeddings

### DIFF
--- a/src/datastore/pinecone/datastore.test.ts
+++ b/src/datastore/pinecone/datastore.test.ts
@@ -12,7 +12,7 @@ vi.mock('../../model/index.js', () => {
     .fn()
     .mockImplementation((args: { input: string[] }) => {
       if (args.input.length === 1) {
-        return { embedings: [[1, 1]] };
+        return { embeddings: [[1, 1]] };
       } else {
         return {
           embeddings: [

--- a/src/datastore/pinecone/datastore.test.ts
+++ b/src/datastore/pinecone/datastore.test.ts
@@ -12,9 +12,14 @@ vi.mock('../../model/index.js', () => {
     .fn()
     .mockImplementation((args: { input: string[] }) => {
       if (args.input.length === 1) {
-        return { data: [{ embedding: [1, 1] }] };
+        return { embedings: [[1, 1]] };
       } else {
-        return { data: [{ embedding: [1, 1] }, { embedding: [2, 2] }] };
+        return {
+          embeddings: [
+            [1, 1],
+            [2, 2],
+          ],
+        };
       }
     });
   SparseVectorModel.prototype.run = vi

--- a/src/datastore/pinecone/datastore.ts
+++ b/src/datastore/pinecone/datastore.ts
@@ -38,13 +38,13 @@ export class PineconeDatastore<
 
     // If no query embedding is provided, run the query embedder
     if (!queryEmbedding) {
-      const { data } = await this.embeddingModel.run(
+      const { embeddings } = await this.embeddingModel.run(
         {
           input: [query.query],
         },
         mergedContext
       );
-      const embedding = data[0].embedding;
+      const embedding = embeddings[0];
       queryEmbedding = embedding;
     }
 
@@ -108,7 +108,7 @@ export class PineconeDatastore<
         { input: textsToEmbed },
         mergedContext
       );
-      const embeddings = embeddingRes.data.map((item) => item.embedding);
+      const embeddings = embeddingRes.embeddings;
 
       // Merge the existing embeddings and sparse vectors with the generated ones
       const docsWithEmbeddings = docs.map((doc) => {

--- a/src/datastore/pinecone/hybrid-datastore.ts
+++ b/src/datastore/pinecone/hybrid-datastore.ts
@@ -38,13 +38,13 @@ export class PineconeHybridDatastore<
     const queryEmbedding = query.embedding;
     const querySparseVector = query.sparseVector;
     const [
-      { data },
+      { embeddings },
       {
         vectors: [sparseVector],
       },
     ] = await Promise.all([
       queryEmbedding
-        ? { data: [{ embedding: queryEmbedding }] }
+        ? { embeddings: [queryEmbedding] }
         : this.embeddingModel.run(
             {
               input: [query.query],
@@ -60,7 +60,7 @@ export class PineconeHybridDatastore<
             mergedContext
           ),
     ]);
-    const embedding = data[0].embedding;
+    const embedding = embeddings[0];
 
     // Query Pinecone
     const response = await this.pinecone.query({
@@ -125,7 +125,7 @@ export class PineconeHybridDatastore<
         this.spladeModel.run({ input: textsToEmbed }, mergedContext),
       ]);
 
-      const embeddings = embeddingRes.data.map((item) => item.embedding);
+      const embeddings = embeddingRes.embeddings;
 
       // Merge the existing embeddings and sparse vectors with the generated ones
       const docsWithEmbeddings = docs.map((doc) => {

--- a/src/model/embedding.ts
+++ b/src/model/embedding.ts
@@ -143,6 +143,7 @@ export class EmbeddingModel extends AbstractModel<
       ...firstBatch,
       usage,
       data: embeddingsObjs,
+      embeddings: embeddingsObjs.map((item) => item.embedding),
       cached: false,
       cost: calculateCost({ model: params.model, tokens: usage }),
     };

--- a/src/model/embedding.ts
+++ b/src/model/embedding.ts
@@ -143,7 +143,7 @@ export class EmbeddingModel extends AbstractModel<
       ...firstBatch,
       usage,
       data: embeddingsObjs,
-      embeddings: embeddingsObjs.map((item) => item.embedding),
+      embeddings: embeddingBatches.map((batch) => batch.embeddings).flat(),
       cached: false,
       cost: calculateCost({ model: params.model, tokens: usage }),
     };


### PR DESCRIPTION
This was changed from using the embeddings property of the response to
the data property, which means it will break for any values cached prior
to the change.
