### PR TITLE
problem calling functions in handleUpdate mode ​

### DIFF
--- a/src/model/chat.ts
+++ b/src/model/chat.ts
@@ -114,15 +114,29 @@ export class ChatModel extends AbstractModel<
         }
 
         // Merge the delta into the chunk
-        const { content, function_call } = delta;
+        const { content, tool_calls } = delta;
+                
         if (content) {
-          chunk.choices[0].delta.content = `${chunk.choices[0].delta.content}${content}`;
+            chunk.choices[0].delta.content = `${chunk.choices[0].delta.content}${content}`;
         }
-        if (function_call) {
-          chunk.choices[0].delta.function_call = deepMerge(
-            chunk.choices[0].delta.function_call,
-            function_call
-          );
+        
+        if (tool_calls) {
+          
+            const mergedToolCalls = chunk.choices[0].delta.tool_calls || [];
+
+              tool_calls.forEach((new_call) => {
+                const index = new_call.index;
+                let existing_call = mergedToolCalls.find(call => call.index === index);
+
+                if (existing_call) {
+                  existing_call.function.arguments += new_call.function.arguments;
+                } else {
+                  mergedToolCalls.push(new_call);
+                }
+              });
+
+              chunk.choices[0].delta.tool_calls = mergedToolCalls;
+
         }
       }
 

--- a/src/model/chat.ts
+++ b/src/model/chat.ts
@@ -117,26 +117,24 @@ export class ChatModel extends AbstractModel<
         const { content, tool_calls } = delta;
                 
         if (content) {
-            chunk.choices[0].delta.content = `${chunk.choices[0].delta.content}${content}`;
+          chunk.choices[0].delta.content = `${chunk.choices[0].delta.content}${content}`;
         }
         
         if (tool_calls) {
-          
-            const mergedToolCalls = chunk.choices[0].delta.tool_calls || [];
+          const mergedToolCalls = chunk.choices[0].delta.tool_calls || [];
 
-              tool_calls.forEach((new_call) => {
-                const index = new_call.index;
-                let existing_call = mergedToolCalls.find(call => call.index === index);
+          tool_calls.forEach((new_call) => {
+            const index = new_call.index;
+            let existing_call = mergedToolCalls.find(call => call.index === index);
 
-                if (existing_call) {
-                  existing_call.function.arguments += new_call.function.arguments;
-                } else {
-                  mergedToolCalls.push(new_call);
-                }
-              });
+            if (existing_call) {
+              existing_call.function.arguments += new_call.function.arguments;
+            } else {
+              mergedToolCalls.push(new_call);
+            }
+          });
 
-              chunk.choices[0].delta.tool_calls = mergedToolCalls;
-
+          chunk.choices[0].delta.tool_calls = mergedToolCalls;
         }
       }
 


### PR DESCRIPTION
When calling the get weather example (and any other function), I would get a response with empty arguments, which would cause an error. To repeat the problem, try to call the function with the handleUpdate argument. It fill be fail.  In order to fix the problem, we had to rewrite the build function tool_calls, replacing the deprecated function_call. Anyway, I attach the code - everything works now. 