### PR TITLE
feat: Allow async cacheKey option

### DIFF
--- a/src/datastore/datastore.ts
+++ b/src/datastore/datastore.ts
@@ -71,7 +71,7 @@ export abstract class AbstractDatastore<
       ) ?? []
     );
 
-    const cacheKey = this.cacheKey(query);
+    const cacheKey = await this.cacheKey(query);
 
     // Return cached response if available
     const cached = await Promise.resolve(this.cache?.get(cacheKey));

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -97,7 +97,7 @@ export abstract class AbstractModel<
       ) ?? []
     );
 
-    const cacheKey = this.cacheKey(mergedParams);
+    const cacheKey = await this.cacheKey(mergedParams);
 
     try {
       // Check the cache

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -7,7 +7,7 @@ export type CacheStorage<KeyType, ValueType extends any> = {
 
 export type CacheKey<Params extends Record<string, any>, KeyType = string> = (
   params: Params
-) => KeyType;
+) => KeyType | Promise<KeyType>;
 
 export function defaultCacheKey<Params extends Record<string, any>>(
   params: Params


### PR DESCRIPTION
 - Required change to be able to use hashing functions in crypto.subtle
 
 Example usage:
 ```ts
 /** uses json stringify + a web string hash using subtle crypto */
function cacheKey(value: unknown) {
  const json = JSON.stringify(value);
  const buffer = new TextEncoder().encode(json);
  return crypto.subtle.digest("SHA-1", buffer).then((hash) => {
    const hashArray = new Uint8Array(hash);
    let result = "";
    for (let i = 0; i < hashArray.length; i++) {
      result += hashArray[i].toString(16).padStart(2, "0");
    }
    return result;
  });
}
```