### PR TITLE
fix: remove console.warn about missing cost

### DIFF
--- a/src/model/utils/calculate-cost.ts
+++ b/src/model/utils/calculate-cost.ts
@@ -118,7 +118,5 @@ function getCost(model: string): Cost | null {
   if (model.startsWith('ada:ft')) return COSTS['ft-legacy:ada'];
   if (model.startsWith('babbage:ft')) return COSTS['ft-legacy:babbage'];
 
-  console.warn(`No OpenAI cost found for model "${model}"`);
-
   return null;
 }


### PR DESCRIPTION
Fixes #28 

We can always add logging at the application-level if `cost` is `null` / `undefined`. This `console.warn` doesn't really fit in a library like this and makes using non-openai models awkward.