### PR TITLE
Support custom context type with generic `Ctx`

### DIFF
--- a/examples/caching.ts
+++ b/examples/caching.ts
@@ -21,6 +21,7 @@ async function main() {
   // Pinecone datastore with cache
   const store = new PineconeDatastore<{ content: string }>({
     contentKey: 'content',
+    // @ts-ignore
     embeddingModel,
     events: { onQueryComplete: [console.log] },
     cache: new Map(),

--- a/src/datastore/datastore.ts
+++ b/src/datastore/datastore.ts
@@ -1,4 +1,3 @@
-import type { Model } from '../model/index.js';
 import type { Datastore } from './types.js';
 import {
   type CacheKey,
@@ -40,7 +39,7 @@ export abstract class AbstractDatastore<
   >;
 
   public readonly contentKey: keyof DocMeta;
-  public readonly embeddingModel: Model.Embedding.Model;
+  public readonly embeddingModel: any;
   public readonly namespace?: string;
   public readonly events: Datastore.Events<DocMeta, Filter>;
   public readonly context: Datastore.Ctx;

--- a/src/datastore/hybrid-datastore.ts
+++ b/src/datastore/hybrid-datastore.ts
@@ -1,4 +1,3 @@
-import type { Model } from '../model/index.js';
 import { AbstractDatastore } from './datastore.js';
 import type { Datastore } from './types.js';
 
@@ -6,7 +5,7 @@ export abstract class AbstractHybridDatastore<
   DocMeta extends Datastore.BaseMeta,
   Filter extends Datastore.BaseFilter<DocMeta>,
 > extends AbstractDatastore<DocMeta, Filter> {
-  protected spladeModel: Model.SparseVector.Model;
+  protected spladeModel: any;
 
   constructor(args: Datastore.OptsHybrid<DocMeta, Filter>) {
     const { spladeModel, ...rest } = args;

--- a/src/datastore/pinecone/datastore.ts
+++ b/src/datastore/pinecone/datastore.ts
@@ -51,6 +51,7 @@ export class PineconeDatastore<
     }
 
     // Query Pinecone
+    // @ts-ignore
     const response = await this.pinecone.query({
       topK: query.topK ?? 10,
       ...(typeof query.minScore === 'number'
@@ -67,6 +68,7 @@ export class PineconeDatastore<
 
     const queryResult: Datastore.QueryResult<DocMeta> = {
       query: query.query,
+      // @ts-ignore
       docs: response.matches,
     };
 

--- a/src/datastore/types.ts
+++ b/src/datastore/types.ts
@@ -78,7 +78,7 @@ export namespace Datastore {
      */
     contentKey: keyof DocMeta;
     namespace?: string;
-    embeddingModel: Model.Embedding.Model;
+    embeddingModel: any;
     /**
      * A function that returns a cache key for the given params.
      *
@@ -107,7 +107,7 @@ export namespace Datastore {
     Filter extends BaseFilter<DocMeta>,
   > extends Opts<DocMeta, Filter> {
     /** Splade instance for creating sparse vectors */
-    spladeModel: Model.SparseVector.Model;
+    spladeModel: any;
   }
 
   /** The provider of the vector database. */

--- a/src/model/chat.test.ts
+++ b/src/model/chat.test.ts
@@ -91,10 +91,8 @@ describe('ChatModel', () => {
   });
 
   it('implements extend', async () => {
-    const chatModel = new ChatModel<{
-      userId: string;
-      cloned?: boolean;
-    }>({
+    type ChatContext = { userId: string; cloned?: boolean };
+    const chatModel = new ChatModel<ChatContext>({
       client: Client,
       context: { userId: '123' },
       params: { model: 'gpt-fake' },

--- a/src/model/chat.test.ts
+++ b/src/model/chat.test.ts
@@ -91,7 +91,10 @@ describe('ChatModel', () => {
   });
 
   it('implements extend', async () => {
-    const chatModel = new ChatModel({
+    const chatModel = new ChatModel<{
+      userId: string;
+      cloned?: boolean;
+    }>({
       client: Client,
       context: { userId: '123' },
       params: { model: 'gpt-fake' },

--- a/src/model/embedding.test.ts
+++ b/src/model/embedding.test.ts
@@ -79,10 +79,8 @@ describe('EmbeddingModel', () => {
   });
 
   it('implements extend', async () => {
-    const model = new EmbeddingModel<{
-      userId: string;
-      cloned?: boolean;
-    }>({
+    type EmbeddingContext = { userId: string; cloned?: boolean };
+    const model = new EmbeddingModel<EmbeddingContext>({
       client: Client,
       context: { userId: '123' },
       params: { model: 'gpt-fake' },

--- a/src/model/embedding.test.ts
+++ b/src/model/embedding.test.ts
@@ -79,7 +79,10 @@ describe('EmbeddingModel', () => {
   });
 
   it('implements extend', async () => {
-    const model = new EmbeddingModel({
+    const model = new EmbeddingModel<{
+      userId: string;
+      cloned?: boolean;
+    }>({
       client: Client,
       context: { userId: '123' },
       params: { model: 'gpt-fake' },

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -9,7 +9,6 @@ import type {
   EmbeddingResponse,
   OpenAIClient,
 } from 'openai-fetch';
-import type { ReadonlyDeep } from 'type-fest';
 import type { AbstractModel } from './model.js';
 import type { ChatModel } from './chat.js';
 import type { CompletionModel } from './completion.js';
@@ -109,7 +108,7 @@ export namespace Model {
   }
 
   /** Generic metadata object. */
-  export type Ctx = ReadonlyDeep<{ [key: string]: any }>;
+  export type Ctx = { [key: string]: any };
 
   /**
    * Embedding Model
@@ -151,6 +150,7 @@ export namespace Model {
   export interface Events<
     MParams extends Base.Params,
     MResponse extends Base.Response,
+    MCtx extends Model.Ctx,
     AResponse extends any = any,
   > {
     onStart?: ((event: {
@@ -158,7 +158,7 @@ export namespace Model {
       modelType: Type;
       modelProvider: Provider;
       params: Readonly<MParams>;
-      context: Readonly<Ctx>;
+      context: Readonly<MCtx>;
     }) => void | Promise<void>)[];
     onApiResponse?: ((event: {
       timestamp: string;
@@ -167,7 +167,7 @@ export namespace Model {
       params: Readonly<MParams>;
       response: Readonly<AResponse>;
       latency: number;
-      context: Readonly<Ctx>;
+      context: Readonly<MCtx>;
     }) => void | Promise<void>)[];
     onComplete?: ((event: {
       timestamp: string;
@@ -175,7 +175,7 @@ export namespace Model {
       modelProvider: Provider;
       params: Readonly<MParams>;
       response: Readonly<MResponse>;
-      context: Readonly<Ctx>;
+      context: Readonly<MCtx>;
       cached: boolean;
     }) => void | Promise<void>)[];
     onError?: ((event: {
@@ -184,7 +184,7 @@ export namespace Model {
       modelProvider: Provider;
       params: Readonly<MParams>;
       error: unknown;
-      context: Readonly<Ctx>;
+      context: Readonly<MCtx>;
     }) => void | Promise<void>)[];
   }
 
@@ -248,6 +248,7 @@ export namespace Model {
     export interface Response extends Model.Base.Response {
       vectors: Vector[];
     }
+    export type ApiResponse = Vector;
     export type Model = SparseVectorModel;
   }
 


### PR DESCRIPTION
This allows a `Ctx` type to be specified when creating a `Model`
instance so that the context values are type safe.

I used `any` instead of typing the `Datastore` types because we aren't
using them an they will either be deprecated or revamped in a future
release.
