### PR TITLE
add opt for passing abort signal to chatCompletion function

### DIFF
--- a/examples/abort-chat-completion.ts
+++ b/examples/abort-chat-completion.ts
@@ -14,21 +14,18 @@ async function main() {
     },
   });
 
-  const messages: Prompt.Msg[] = [
-    Msg.user(`Write a short story`),
-  ];
+  const messages: Prompt.Msg[] = [Msg.user(`Write a short story`)];
 
   {
-    const abortController = new AbortController()
+    const abortController = new AbortController();
     abortController.signal.addEventListener('abort', () => {
-      console.log('\n\nAborted')
-    })
+      console.log('\n\nAborted');
+    });
 
     try {
-
       setTimeout(() => {
-        abortController.abort()
-      }, 2000)
+        abortController.abort();
+      }, 2000);
 
       // Invoke the chat model with the result
       await chatModel.run({
@@ -40,12 +37,11 @@ async function main() {
           // Note: The abort doesn't always cancel the request, so we need to handle when the request is aborted
           // here as well.
           if (abortController.signal.aborted) {
-            return
+            return;
           }
-          process.stdout.write(c)
-        }
+          process.stdout.write(c);
+        },
       });
-
 
       // console.log(message.content);
     } catch (error) {

--- a/examples/abort-chat-completion.ts
+++ b/examples/abort-chat-completion.ts
@@ -1,0 +1,57 @@
+import 'dotenv/config';
+import { ChatModel, Msg, type Prompt } from '@dexaai/dexter';
+
+/**
+ * npx tsx examples/abort-chat-completion.ts
+ */
+async function main() {
+  const chatModel = new ChatModel({
+    debug: true,
+    params: {
+      model: 'gpt-3.5-turbo',
+      temperature: 0.5,
+      max_tokens: 1000,
+    },
+  });
+
+  const messages: Prompt.Msg[] = [
+    Msg.user(`Write a short story`),
+  ];
+
+  {
+    const abortController = new AbortController()
+    abortController.signal.addEventListener('abort', () => {
+      console.log('\n\nAborted')
+    })
+
+    try {
+
+      setTimeout(() => {
+        abortController.abort()
+      }, 2000)
+
+      // Invoke the chat model with the result
+      await chatModel.run({
+        messages,
+        requestOpts: {
+          signal: abortController.signal,
+        },
+        handleUpdate: (c) => {
+          // Note: The abort doesn't always cancel the request, so we need to handle when the request is aborted
+          // here as well.
+          if (abortController.signal.aborted) {
+            return
+          }
+          process.stdout.write(c)
+        }
+      });
+
+
+      // console.log(message.content);
+    } catch (error) {
+      console.error('Error during chat model run:', error);
+    }
+  }
+}
+
+main();

--- a/src/model/chat.ts
+++ b/src/model/chat.ts
@@ -65,7 +65,7 @@ export class ChatModel<
   }
 
   protected async runModel(
-    { handleUpdate, opts, ...params }: Model.Chat.Run & Model.Chat.Config,
+    { handleUpdate, requestOpts, ...params }: Model.Chat.Run & Model.Chat.Config,
     context: CustomCtx
   ): Promise<Model.Chat.Response> {
     const start = Date.now();
@@ -73,7 +73,7 @@ export class ChatModel<
     // Use non-streaming API if no handler is provided
     if (!handleUpdate) {
       // Make the OpenAI API request
-      const response = await this.client.createChatCompletion(params, opts);
+      const response = await this.client.createChatCompletion(params, requestOpts);
 
       await Promise.allSettled(
         this.events?.onApiResponse?.map((event) =>
@@ -102,7 +102,7 @@ export class ChatModel<
       return modelResponse;
     } else {
       // Use the streaming API if a handler is provided
-      const stream = await this.client.streamChatCompletion(params);
+      const stream = await this.client.streamChatCompletion(params, requestOpts);
 
       // Keep track of the stream's output
       let chunk = {} as Model.Chat.CompletionChunk;

--- a/src/model/chat.ts
+++ b/src/model/chat.ts
@@ -65,7 +65,7 @@ export class ChatModel<
   }
 
   protected async runModel(
-    { handleUpdate, ...params }: Model.Chat.Run & Model.Chat.Config,
+    { handleUpdate, opts, ...params }: Model.Chat.Run & Model.Chat.Config,
     context: CustomCtx
   ): Promise<Model.Chat.Response> {
     const start = Date.now();
@@ -73,7 +73,7 @@ export class ChatModel<
     // Use non-streaming API if no handler is provided
     if (!handleUpdate) {
       // Make the OpenAI API request
-      const response = await this.client.createChatCompletion(params);
+      const response = await this.client.createChatCompletion(params, opts);
 
       await Promise.allSettled(
         this.events?.onApiResponse?.map((event) =>

--- a/src/model/chat.ts
+++ b/src/model/chat.ts
@@ -65,7 +65,11 @@ export class ChatModel<
   }
 
   protected async runModel(
-    { handleUpdate, requestOpts, ...params }: Model.Chat.Run & Model.Chat.Config,
+    {
+      handleUpdate,
+      requestOpts,
+      ...params
+    }: Model.Chat.Run & Model.Chat.Config,
     context: CustomCtx
   ): Promise<Model.Chat.Response> {
     const start = Date.now();
@@ -73,7 +77,10 @@ export class ChatModel<
     // Use non-streaming API if no handler is provided
     if (!handleUpdate) {
       // Make the OpenAI API request
-      const response = await this.client.createChatCompletion(params, requestOpts);
+      const response = await this.client.createChatCompletion(
+        params,
+        requestOpts
+      );
 
       await Promise.allSettled(
         this.events?.onApiResponse?.map((event) =>
@@ -102,7 +109,10 @@ export class ChatModel<
       return modelResponse;
     } else {
       // Use the streaming API if a handler is provided
-      const stream = await this.client.streamChatCompletion(params, requestOpts);
+      const stream = await this.client.streamChatCompletion(
+        params,
+        requestOpts
+      );
 
       // Keep track of the stream's output
       let chunk = {} as Model.Chat.CompletionChunk;

--- a/src/model/clients/splade.ts
+++ b/src/model/clients/splade.ts
@@ -1,4 +1,4 @@
-import ky from 'ky';
+import ky, { type Options as KYOptions } from 'ky';
 import type { Model } from '../types.js';
 
 export const createSpladeClient = () => ({
@@ -6,6 +6,9 @@ export const createSpladeClient = () => ({
     params: {
       input: string;
       model: string;
+      requestOpts?: {
+        headers?: KYOptions['headers'];
+      };
     },
     serviceUrl: string
   ): Promise<Model.SparseVector.Vector> {
@@ -14,6 +17,7 @@ export const createSpladeClient = () => ({
         .post(serviceUrl, {
           timeout: 1000 * 60,
           json: { text: params.input },
+          headers: params.requestOpts?.headers,
         })
         .json<Model.SparseVector.Vector>();
       return sparseValues;

--- a/src/model/completion.ts
+++ b/src/model/completion.ts
@@ -51,7 +51,6 @@ export class CompletionModel<
   ): Promise<Model.Completion.Response> {
     const start = Date.now();
 
-
     // Make the OpenAI API request
     const response = await this.client.createCompletions(params, requestOpts);
 

--- a/src/model/completion.ts
+++ b/src/model/completion.ts
@@ -46,13 +46,14 @@ export class CompletionModel<
   }
 
   protected async runModel(
-    params: Model.Completion.Run & Model.Completion.Config,
+    { requestOpts, ...params }: Model.Completion.Run & Model.Completion.Config,
     context: CustomCtx
   ): Promise<Model.Completion.Response> {
     const start = Date.now();
 
+
     // Make the OpenAI API request
-    const response = await this.client.createCompletions(params);
+    const response = await this.client.createCompletions(params, requestOpts);
 
     await Promise.allSettled(
       this.events?.onApiResponse?.map((event) =>

--- a/src/model/embedding.ts
+++ b/src/model/embedding.ts
@@ -115,7 +115,7 @@ export class EmbeddingModel<
   }
 
   protected async runModel(
-    params: Model.Embedding.Run & Model.Embedding.Config,
+    { requestOpts, ...params }: Model.Embedding.Run & Model.Embedding.Config,
     context: CustomCtx
   ): Promise<Model.Embedding.Response> {
     const start = Date.now();
@@ -136,6 +136,7 @@ export class EmbeddingModel<
           {
             input: batch,
             model: this.params.model,
+            requestOpts,
           },
           mergedContext
         );

--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -6,17 +6,23 @@ import type { Model } from './types.js';
 class Test extends AbstractModel<
   any,
   { model: string },
-  { input: string, requestOpts?: {
-    signal?: AbortSignal
-  } },
+  {
+    input: string;
+    requestOpts?: {
+      signal?: AbortSignal;
+    };
+  },
   { output: string; cached: boolean }
 > {
   modelType = 'completion' as Model.Type;
   modelProvider = 'custom' as Model.Provider;
   async runModel(
-    params: { input: string, requestOpts?: {
-      signal?: AbortSignal
-    } },
+    params: {
+      input: string;
+      requestOpts?: {
+        signal?: AbortSignal;
+      };
+    },
     context: Model.Ctx
   ): Promise<{ output: string; cached: boolean }> {
     if (params.input === 'throw error') {
@@ -101,17 +107,26 @@ describe('AbstractModel', () => {
   it('can take in a signal', async () => {
     const abortController = new AbortController();
     const test = new Test({ params: { model: 'testmodel' }, client: false });
-    const result = await test.run({ input: 'fooin', requestOpts: {
-      signal: abortController.signal
-    } }, { userId: '123' });
+    const result = await test.run(
+      {
+        input: 'fooin',
+        requestOpts: {
+          signal: abortController.signal,
+        },
+      },
+      { userId: '123' }
+    );
 
     const runModelSpy = vi.spyOn(test, 'runModel');
-    await test.run({ input: 'fooin', requestOpts: { signal: abortController.signal } }, { userId: '123' });
+    await test.run(
+      { input: 'fooin', requestOpts: { signal: abortController.signal } },
+      { userId: '123' }
+    );
     expect(runModelSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         requestOpts: expect.objectContaining({
-          signal: abortController.signal
-        })
+          signal: abortController.signal,
+        }),
       }),
       expect.objectContaining({ userId: '123' })
     );

--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -6,13 +6,17 @@ import type { Model } from './types.js';
 class Test extends AbstractModel<
   any,
   { model: string },
-  { input: string },
+  { input: string, requestOpts?: {
+    signal?: AbortSignal
+  } },
   { output: string; cached: boolean }
 > {
   modelType = 'completion' as Model.Type;
   modelProvider = 'custom' as Model.Provider;
-  protected async runModel(
-    params: { input: string },
+  async runModel(
+    params: { input: string, requestOpts?: {
+      signal?: AbortSignal
+    } },
     context: Model.Ctx
   ): Promise<{ output: string; cached: boolean }> {
     if (params.input === 'throw error') {
@@ -92,5 +96,29 @@ describe('AbstractModel', () => {
     // onComplete is called for cached responses
     expect(completeEvent).toHaveBeenCalledTimes(2);
     expect(completeEvent.mock.lastCall[0].cached).toBe(true);
+  });
+
+  it('can take in a signal', async () => {
+    const abortController = new AbortController();
+    const test = new Test({ params: { model: 'testmodel' }, client: false });
+    const result = await test.run({ input: 'fooin', requestOpts: {
+      signal: abortController.signal
+    } }, { userId: '123' });
+
+    const runModelSpy = vi.spyOn(test, 'runModel');
+    await test.run({ input: 'fooin', requestOpts: { signal: abortController.signal } }, { userId: '123' });
+    expect(runModelSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestOpts: expect.objectContaining({
+          signal: abortController.signal
+        })
+      }),
+      expect.objectContaining({ userId: '123' })
+    );
+
+    expect(result).toEqual({
+      output: 'fooin > AI response with context: {"userId":"123"}',
+      cached: false,
+    });
   });
 });

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -8,6 +8,7 @@ import {
   defaultCacheKey,
 } from '../utils/cache.js';
 
+
 export interface ModelArgs<
   MClient extends Model.Base.Client,
   MConfig extends Model.Base.Config,
@@ -110,8 +111,13 @@ export abstract class AbstractModel<
     context?: CustomCtx
   ): Promise<MResponse> {
     const start = Date.now();
+
     const mergedContext = deepMerge(this.context, context);
-    const mergedParams = deepMerge(this.params, params);
+    const mergedParams = {
+      ...this.params,
+      ...params,
+    }
+
 
     await Promise.allSettled(
       this.events.onStart?.map((event) =>

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -8,7 +8,6 @@ import {
   defaultCacheKey,
 } from '../utils/cache.js';
 
-
 export interface ModelArgs<
   MClient extends Model.Base.Client,
   MConfig extends Model.Base.Config,
@@ -113,11 +112,12 @@ export abstract class AbstractModel<
     const start = Date.now();
 
     const mergedContext = deepMerge(this.context, context);
-    const mergedParams = {
-      ...this.params,
-      ...params,
-    }
+    const mergedParams = deepMerge(this.params, params);
 
+    // Handle signal separately since it's a instance of AbortSignal
+    if (params.requestOpts?.signal && mergedParams.requestOpts) {
+      mergedParams.requestOpts.signal = params.requestOpts.signal;
+    }
 
     await Promise.allSettled(
       this.events.onStart?.map((event) =>

--- a/src/model/sparse-vector.ts
+++ b/src/model/sparse-vector.ts
@@ -55,7 +55,10 @@ export class SparseVectorModel<
   }
 
   protected async runModel(
-    { requestOpts, ...params }: Model.SparseVector.Run & Model.SparseVector.Config,
+    {
+      requestOpts,
+      ...params
+    }: Model.SparseVector.Run & Model.SparseVector.Config,
     context: CustomCtx
   ): Promise<Model.SparseVector.Response> {
     const start = Date.now();
@@ -86,10 +89,10 @@ export class SparseVectorModel<
   protected async runSingle(
     params: {
       input: string;
-      model: string,
+      model: string;
       requestOpts?: {
-        headers?: KYOptions['headers']
-      }
+        headers?: KYOptions['headers'];
+      };
     },
     context: CustomCtx
   ): Promise<{

--- a/src/model/sparse-vector.ts
+++ b/src/model/sparse-vector.ts
@@ -1,6 +1,7 @@
 import type { PartialDeep } from 'type-fest';
 import pThrottle from 'p-throttle';
 import pMap from 'p-map';
+import { type Options as KYOptions } from 'ky';
 import type { ModelArgs } from './model.js';
 import { AbstractModel } from './model.js';
 import type { Model } from './types.js';
@@ -54,7 +55,7 @@ export class SparseVectorModel<
   }
 
   protected async runModel(
-    params: Model.SparseVector.Run & Model.SparseVector.Config,
+    { requestOpts, ...params }: Model.SparseVector.Run & Model.SparseVector.Config,
     context: CustomCtx
   ): Promise<Model.SparseVector.Response> {
     const start = Date.now();
@@ -83,7 +84,13 @@ export class SparseVectorModel<
   }
 
   protected async runSingle(
-    params: { input: string; model: string },
+    params: {
+      input: string;
+      model: string,
+      requestOpts?: {
+        headers?: KYOptions['headers']
+      }
+    },
     context: CustomCtx
   ): Promise<{
     vector: Model.SparseVector.Vector;

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -9,11 +9,13 @@ import type {
   EmbeddingResponse,
   OpenAIClient,
 } from 'openai-fetch';
+import { type Options as KYOptions } from 'ky';
 import type { AbstractModel } from './model.js';
 import type { ChatModel } from './chat.js';
 import type { CompletionModel } from './completion.js';
 import type { EmbeddingModel } from './embedding.js';
 import type { SparseVectorModel } from './sparse-vector.js';
+
 
 type InnerType<T> = T extends ReadableStream<infer U> ? U : never;
 
@@ -30,7 +32,13 @@ export namespace Model {
     export interface Config {
       model: string;
     }
-    export interface Run {}
+    export interface Run {
+      [key: string]: any;
+      requestOpts?: {
+        signal?: AbortSignal;
+        headers?: KYOptions['headers'];
+      };
+    }
     export interface Params extends Config, Run {}
     export interface Response {
       cached: boolean;
@@ -50,9 +58,6 @@ export namespace Model {
     };
     export interface Run extends Base.Run {
       messages: Model.Message[];
-      opts?: {
-        signal?: AbortSignal;
-      };
     }
     export interface Config extends Base.Config {
       /** Handle new chunk from streaming requests. */
@@ -231,6 +236,9 @@ export namespace Model {
         params: {
           input: string;
           model: string;
+          requestOpts?: {
+            headers?: KYOptions['headers'];
+          };
         },
         serviceUrl: string
       ) => Promise<SparseVector.Vector>;

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -50,6 +50,9 @@ export namespace Model {
     };
     export interface Run extends Base.Run {
       messages: Model.Message[];
+      opts?: {
+        signal?: AbortSignal;
+      };
     }
     export interface Config extends Base.Config {
       /** Handle new chunk from streaming requests. */

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -16,7 +16,6 @@ import type { CompletionModel } from './completion.js';
 import type { EmbeddingModel } from './embedding.js';
 import type { SparseVectorModel } from './sparse-vector.js';
 
-
 type InnerType<T> = T extends ReadableStream<infer U> ? U : never;
 
 /**

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -4,7 +4,8 @@ import { deepmerge as deepmergeInit } from '@fastify/deepmerge';
 export type Prettify<T> = { [K in keyof T]: T[K] } & {};
 
 type DeepMerge = ReturnType<typeof deepmergeInit>;
-const deepMergeImpl: DeepMerge = deepmergeInit();
+export const deepMergeImpl: DeepMerge = deepmergeInit();
+
 const deepMergeEventsImpl: DeepMerge = deepmergeInit({
   // Note: this is not using a recursive deep merge since it isn't used for events.
   mergeArray: () => (a: any[], b: any[]) => stableDedupe([...a, ...b]),


### PR DESCRIPTION
Attempts to add the option to pass an abort signal through to the chatCompletion function.

(This isn't fully working yet.)

Notes:
- Aborting the request seems to only work semi-consistently.
- For Streaming, the work around is to just check if the signal is aborted when the chunk is received and handle it there.

TLDR still investigating how to abort properly
