### PR TITLE
Fix `deepMerge` for array of tool objects

### DIFF
--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -13,6 +13,64 @@ describe('utils.helpers', () => {
     });
   });
 
+  it('deepMerge tools', () => {
+    expect(
+      deepMerge(
+        {
+          foo: [
+            {
+              type: 'function',
+              function: {
+                name: 'foo',
+                description: 'foo function',
+                arguments: { bar: 'baz' },
+              },
+            },
+          ],
+        },
+        {
+          foo: [
+            {
+              type: 'function',
+              function: {
+                name: 'foo',
+                description: 'foo function',
+                arguments: { bar: 'baz' },
+              },
+            },
+            {
+              type: 'function',
+              function: {
+                name: 'foo2',
+                description: 'foo function2',
+                arguments: { bar: 'baz2' },
+              },
+            },
+          ],
+        }
+      )
+    ).toEqual({
+      foo: [
+        {
+          type: 'function',
+          function: {
+            name: 'foo',
+            description: 'foo function',
+            arguments: { bar: 'baz' },
+          },
+        },
+        {
+          type: 'function',
+          function: {
+            name: 'foo2',
+            description: 'foo function2',
+            arguments: { bar: 'baz2' },
+          },
+        },
+      ],
+    });
+  });
+
   it('mergeEvents', () => {
     expect(mergeEvents(undefined, {})).toEqual({});
     expect(mergeEvents({}, undefined)).toEqual({});


### PR DESCRIPTION
This makes it so that the `deepMerge` function can handle merging arrays of tool objects.

Resolves #40 