### PR TITLE
Add telemetry abstraction to remove Sentry dep (round 2)

### DIFF
--- a/.github/actions/install-node-pnpm/action.yml
+++ b/.github/actions/install-node-pnpm/action.yml
@@ -8,7 +8,7 @@ inputs:
     required: false
   pnpm-version:
     description: 'The version of pnpm to install'
-    default: '8'
+    default: '9'
     required: false
 
 runs:

--- a/examples/instrument.ts
+++ b/examples/instrument.ts
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/node';
+
+/**
+ * Configure Sentry for tracing.
+ * Ensure to call this before importing any other modules!
+ */
+Sentry.init({
+  dsn: process.env.SENTRY_DSN!,
+  tracesSampleRate: 1.0,
+  debug: true,
+});

--- a/examples/with-telemetry.ts
+++ b/examples/with-telemetry.ts
@@ -1,0 +1,19 @@
+import './instrument.js';
+import 'dotenv/config';
+import { ChatModel } from '@dexaai/dexter';
+import * as Sentry from '@sentry/node';
+
+const chatModel = new ChatModel({
+  // Send tracing data to Sentry
+  telemetry: Sentry,
+  params: { model: 'gpt-4o-mini' },
+});
+
+async function main() {
+  const result = await chatModel.run({
+    messages: [{ role: 'user', content: 'Tell me a short joke' }],
+  });
+  console.log(result);
+}
+
+main().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -98,8 +98,5 @@
     "vite": "^5.2.11",
     "vitest": "^1.6.0"
   },
-  "peerDependencies": {
-    "@sentry/node": "8.x"
-  },
   "packageManager": "pnpm@8.6.12"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,5 @@ export * from './datastore/index.js';
 export * from './datastore/pinecone/index.js';
 export * from './model/index.js';
 export * from './prompt/index.js';
+export * from './telemetry/index.js';
 export * from './utils/index.js';

--- a/src/model/chat.ts
+++ b/src/model/chat.ts
@@ -254,6 +254,7 @@ export class ChatModel<
       cache: this.cache,
       client: this.client,
       debug: this.debug,
+      telemetry: this.telemetry,
       ...args,
       params: deepMerge(this.params, args?.params),
       context:

--- a/src/model/completion.ts
+++ b/src/model/completion.ts
@@ -87,6 +87,7 @@ export class CompletionModel<
       cache: this.cache,
       client: this.client,
       debug: this.debug,
+      telemetry: this.telemetry,
       ...args,
       context: deepMerge(this.context, args?.context),
       params: deepMerge(this.params, args?.params),

--- a/src/model/embedding.ts
+++ b/src/model/embedding.ts
@@ -179,6 +179,7 @@ export class EmbeddingModel<
       cache: this.cache,
       client: this.client,
       debug: this.debug,
+      telemetry: this.telemetry,
       ...args,
       context: deepMerge(this.context, args?.context),
       params: deepMerge(this.params, args?.params),

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -41,7 +41,7 @@ export interface ModelArgs<
   context?: Ctx;
   params: MConfig & Partial<MRun>;
   events?: Model.Events<MRun & MConfig, MResponse, Ctx>;
-  telemetry?: Telemetry.Base;
+  telemetry?: Telemetry.Provider;
   /** Whether or not to add default `console.log` event handlers */
   debug?: boolean;
 }
@@ -102,7 +102,7 @@ export abstract class AbstractModel<
     AResponse
   >;
   public readonly tokenizer: Model.ITokenizer;
-  public readonly telemetry: Telemetry.Base;
+  public readonly telemetry: Telemetry.Provider;
 
   constructor(args: ModelArgs<MClient, MConfig, MRun, MResponse, CustomCtx>) {
     this.cacheKey = args.cacheKey ?? defaultCacheKey;

--- a/src/model/sparse-vector.ts
+++ b/src/model/sparse-vector.ts
@@ -136,6 +136,7 @@ export class SparseVectorModel<
       cacheKey: this.cacheKey,
       cache: this.cache,
       debug: this.debug,
+      telemetry: this.telemetry,
       serviceUrl: this.serviceUrl,
       ...args,
       context: deepMerge(this.context, args?.context),

--- a/src/model/utils/telemetry.ts
+++ b/src/model/utils/telemetry.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage, ChatParams } from 'openai-fetch';
+import type { Telemetry } from '../../telemetry/types.js';
 
 const SpanAttrs = {
   LLM_MODEL: 'llm.model',
@@ -21,8 +22,7 @@ const SpanAttrs = {
   LLM_TOKENS_TOTAL: 'llm.tkns.total',
 };
 
-type AttrValue = string | number | boolean | undefined;
-type AttrMap = Record<string, AttrValue>;
+type AttrMap = Telemetry.SpanAttributes;
 
 export function extractAttrsFromContext(context: any): AttrMap {
   try {

--- a/src/telemetry/default-telemetry.ts
+++ b/src/telemetry/default-telemetry.ts
@@ -1,6 +1,6 @@
 import type { Telemetry } from './types.js';
 
-export const DefaultTelemetry: Telemetry.Base = {
+export const DefaultTelemetry: Telemetry.Provider = {
   startSpan<T>(
     _options: Telemetry.SpanOptions,
     callback: (span: Telemetry.Span) => T

--- a/src/telemetry/default-telemetry.ts
+++ b/src/telemetry/default-telemetry.ts
@@ -1,0 +1,23 @@
+import type { Telemetry } from './types.js';
+
+export const DefaultTelemetry: Telemetry.Base = {
+  startSpan<T>(
+    _options: Telemetry.SpanOptions,
+    callback: (span: Telemetry.Span) => T
+  ): T {
+    return callback({
+      setAttribute() {
+        // no-op
+        return this;
+      },
+      setAttributes() {
+        // no-op
+        return this;
+      },
+    });
+  },
+
+  setTags() {
+    // no-op
+  },
+};

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,0 +1,2 @@
+export type { Telemetry } from './types.js';
+export { DefaultTelemetry } from './default-telemetry.js';

--- a/src/telemetry/sentry.test.ts
+++ b/src/telemetry/sentry.test.ts
@@ -1,0 +1,6 @@
+import * as Sentry from '@sentry/node';
+import type { Telemetry } from './types.js';
+
+test('Sentry Telemetry Provider', () => {
+  expectTypeOf(Sentry).toMatchTypeOf<Telemetry.Base>();
+});

--- a/src/telemetry/sentry.test.ts
+++ b/src/telemetry/sentry.test.ts
@@ -2,5 +2,5 @@ import * as Sentry from '@sentry/node';
 import type { Telemetry } from './types.js';
 
 test('Sentry Telemetry Provider', () => {
-  expectTypeOf(Sentry).toMatchTypeOf<Telemetry.Base>();
+  expectTypeOf(Sentry).toMatchTypeOf<Telemetry.Provider>();
 });

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -1,5 +1,5 @@
 export namespace Telemetry {
-  export interface Base {
+  export interface Provider {
     startSpan<T>(options: SpanOptions, callback: (span: Span) => T): T;
 
     setTags(tags: { [key: string]: Primitive }): void;

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -1,0 +1,50 @@
+export namespace Telemetry {
+  export interface Base {
+    startSpan<T>(options: SpanOptions, callback: (span: Span) => T): T;
+
+    setTags(tags: { [key: string]: Primitive }): void;
+  }
+
+  export interface SpanOptions {
+    /** The name of the span. */
+    name: string;
+    /** An op for the span. This is a categorization for spans. */
+    op?: string;
+  }
+
+  /**
+   * A generic Span which holds trace data.
+   */
+  export interface Span {
+    /**
+     * Set a single attribute on the span.
+     * Set it to `undefined` to remove the attribute.
+     */
+    setAttribute(key: string, value: SpanAttributeValue | undefined): this;
+
+    /**
+     * Set multiple attributes on the span.
+     * Any attribute set to `undefined` will be removed.
+     */
+    setAttributes(attributes: SpanAttributes): this;
+  }
+
+  export type Primitive =
+    | number
+    | string
+    | boolean
+    | bigint
+    | symbol
+    | null
+    | undefined;
+
+  export type SpanAttributeValue =
+    | string
+    | number
+    | boolean
+    | Array<null | undefined | string>
+    | Array<null | undefined | number>
+    | Array<null | undefined | boolean>;
+
+  export type SpanAttributes = Record<string, SpanAttributeValue | undefined>;
+}


### PR DESCRIPTION
This is a simplified version of #46. It was easier to copy the important
parts and start clean than try and delete all of the generics code.

Replace the direct dependency on Sentry with the abstract `Telemetry`
interface from @transitive-bullshit. This should have no impact on
users who weren't using the Sentry integration, and requires passing
Sentry as an argument when creating a model instance.

```ts
import { ChatModel } from '@dexaai/dexter'
import * as Sentry from '@sentry/node'

const model = new ChatModel({ telemetry: Sentry })
```

I also added [an example](https://github.com/dexaai/dexter/pull/47/files#diff-130847d7faf197eba8ef5b7f7f257da13a4af6d1fd47f2b33f09d26f64f8d160) of using Sentry for tracing.

## Example Trace
![screenshot-2024-08-08 -T-11-31 png](https://github.com/user-attachments/assets/b27d03df-838d-4374-a62e-131d8feb5cfa)