### PR TITLE
Update `openai-fetch` and handle refusal responses

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/install-node-pnpm
-    - run: pnpm run typecheck
+    - run: pnpm run build && pnpm run typecheck
 
   lint:
     name: Lint

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "hash-object": "^5.0.1",
     "jsonrepair": "^3.8.1",
     "ky": "^1.7.2",
-    "openai-fetch": "2.0.4",
+    "openai-fetch": "3.3.1",
     "p-map": "^7.0.2",
     "p-throttle": "^6.2.0",
     "parse-json": "^8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^1.7.2
         version: 1.7.2
       openai-fetch:
-        specifier: 2.0.4
-        version: 2.0.4
+        specifier: 3.3.1
+        version: 3.3.1
       p-map:
         specifier: ^7.0.2
         version: 7.0.2
@@ -145,16 +145,32 @@ packages:
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.25.7':
+    resolution: {integrity: sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.24.7':
     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.25.7':
+    resolution: {integrity: sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.24.7':
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/highlight@7.25.7':
+    resolution: {integrity: sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/runtime@7.24.6':
     resolution: {integrity: sha512-Ja18XcETdEl5mzzACGd+DKgaGJzPTCow7EglgwTmHdwokzDFYh/MHua6lU6DV/hjF2IaOJ4oX2nqnjG7RElKOw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.25.7':
+    resolution: {integrity: sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==}
     engines: {node: '>=6.9.0'}
 
   '@braintree/sanitize-url@6.0.4':
@@ -3452,8 +3468,8 @@ packages:
     resolution: {integrity: sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==}
     engines: {node: '>=18'}
 
-  openai-fetch@2.0.4:
-    resolution: {integrity: sha512-+1sC+mYpGi79YXaJsySxTtYeWkDULS/fhRCr8PLI+xcpnqFfoFY/VL0f4avQAnJSf1LZRaTrrKOK8yqxrYI5BQ==}
+  openai-fetch@3.3.1:
+    resolution: {integrity: sha512-/b7rPeKLgS+3C2dxQHPiWDj4wOcbL/SF5L2dxktmJyfFza/VK6Mr3+rIldgGxRNpqsa3oonEowafPNx5Tdq9dA==}
     engines: {node: '>=18'}
 
   optionator@0.9.4:
@@ -4654,7 +4670,16 @@ snapshots:
       '@babel/highlight': 7.24.7
       picocolors: 1.1.0
 
+  '@babel/code-frame@7.25.7':
+    dependencies:
+      '@babel/highlight': 7.25.7
+      picocolors: 1.1.0
+    optional: true
+
   '@babel/helper-validator-identifier@7.24.7': {}
+
+  '@babel/helper-validator-identifier@7.25.7':
+    optional: true
 
   '@babel/highlight@7.24.7':
     dependencies:
@@ -4663,9 +4688,22 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.0
 
+  '@babel/highlight@7.25.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.25.7
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+      picocolors: 1.1.0
+    optional: true
+
   '@babel/runtime@7.24.6':
     dependencies:
       regenerator-runtime: 0.14.1
+
+  '@babel/runtime@7.25.7':
+    dependencies:
+      regenerator-runtime: 0.14.1
+    optional: true
 
   '@braintree/sanitize-url@6.0.4': {}
 
@@ -5478,8 +5516,8 @@ snapshots:
 
   '@testing-library/dom@8.20.1':
     dependencies:
-      '@babel/code-frame': 7.24.7
-      '@babel/runtime': 7.24.6
+      '@babel/code-frame': 7.25.7
+      '@babel/runtime': 7.25.7
       '@types/aria-query': 5.0.4
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -8629,7 +8667,7 @@ snapshots:
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
 
-  openai-fetch@2.0.4:
+  openai-fetch@3.3.1:
     dependencies:
       ky: 1.7.2
 

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-use-before-define */
 import { type Options as KYOptions } from 'ky';
 import {
-  type ChatMessage,
   type ChatParams,
   type ChatResponse,
   type ChatStreamResponse,
@@ -12,6 +11,7 @@ import {
   type OpenAIClient,
 } from 'openai-fetch';
 
+import { type Prompt } from '../prompt/types.js';
 import { type ChatModel } from './chat.js';
 import { type CompletionModel } from './completion.js';
 import { type EmbeddingModel } from './embedding.js';
@@ -79,7 +79,7 @@ export namespace Model {
       top_p?: ChatParams['top_p'];
     }
     export interface Response extends Base.Response, ChatResponse {
-      message: ChatMessage;
+      message: Prompt.Msg;
     }
     /** Streaming response from the OpenAI API. */
     type StreamResponse = ChatStreamResponse;
@@ -205,7 +205,7 @@ export namespace Model {
      * A single ChatMessage is counted as a completion and an array as a prompt.
      * Strings are counted as is.
      */
-    countTokens(input?: string | ChatMessage | ChatMessage[]): number;
+    countTokens(input?: string | Prompt.Msg | Prompt.Msg[]): number;
     /** Truncate a string to a maximum number of tokens */
     truncate(args: {
       /** Text to truncate */
@@ -218,7 +218,7 @@ export namespace Model {
   }
 
   /** Primary message type for chat models */
-  export type Message = ChatMessage;
+  export type Message = Prompt.Msg;
 
   /** The provider of the model (eg: OpenAI) */
   export type Provider = (string & {}) | 'openai' | 'custom';

--- a/src/model/utils/tokenizer.ts
+++ b/src/model/utils/tokenizer.ts
@@ -35,8 +35,8 @@ class Tokenizer implements Model.ITokenizer {
     this.model = model;
     try {
       this.tiktoken = encoding_for_model(model as TiktokenModel);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {
-      console.error(`Failed to create tokenizer for model ${model}`, e);
       this.tiktoken = encoding_for_model('gpt-3.5-turbo');
     }
   }

--- a/src/prompt/index.ts
+++ b/src/prompt/index.ts
@@ -10,5 +10,6 @@ export { stringifyForModel } from './functions/stringify-for-model.js';
 export { zodToJsonSchema } from './functions/zod-to-json.js';
 export type { Prompt } from './types.js';
 export * from './utils/errors.js';
+export { AbortError, RefusalError } from './utils/errors.js';
 export { getErrorMsg } from './utils/get-error-message.js';
 export { Msg } from './utils/message.js';

--- a/src/prompt/types.ts
+++ b/src/prompt/types.ts
@@ -146,6 +146,13 @@ export namespace Prompt {
       content: string;
     };
 
+    /** Message with a refusal reason and no content. */
+    export type Refusal = {
+      role: 'assistant';
+      refusal: string;
+      content?: null;
+    };
+
     /** Message with arguments to call a function. */
     export type FuncCall = {
       role: 'assistant';

--- a/src/prompt/utils/errors.ts
+++ b/src/prompt/utils/errors.ts
@@ -17,3 +17,23 @@ export class AbortError extends Error {
     this.message = message;
   }
 }
+
+export class RefusalError extends Error {
+  readonly name: 'RefusalError';
+  readonly originalError: Error;
+
+  constructor(message: string | Error) {
+    super();
+
+    if (message instanceof Error) {
+      this.originalError = message;
+      ({ message } = message);
+    } else {
+      this.originalError = new Error(message);
+      this.originalError.stack = this.stack;
+    }
+
+    this.name = 'RefusalError';
+    this.message = message;
+  }
+}

--- a/src/prompt/utils/message.test.ts
+++ b/src/prompt/utils/message.test.ts
@@ -43,8 +43,12 @@ describe('Msg', () => {
     expect(Msg.isToolResult(msg)).toBe(true);
   });
 
+  // Same as OpenAI.ChatMessage, except we throw a RefusalError if the message is a refusal
+  // so `refusal` isn't on the object and content can't be optional.
   it('prompt message types should interop with openai-fetch message types', () => {
-    expectTypeOf({} as OpenAI.ChatMessage).toMatchTypeOf<Prompt.Msg>();
+    expectTypeOf(
+      {} as Omit<OpenAI.ChatMessage, 'refusal'> & { content: string | null }
+    ).toMatchTypeOf<Prompt.Msg>();
     expectTypeOf({} as Prompt.Msg).toMatchTypeOf<OpenAI.ChatMessage>();
     expectTypeOf({} as Prompt.Msg.System).toMatchTypeOf<OpenAI.ChatMessage>();
     expectTypeOf({} as Prompt.Msg.User).toMatchTypeOf<OpenAI.ChatMessage>();


### PR DESCRIPTION
- **Add build step before typecheck in CI workflow**
- **Catch tokenizer error without console output**
- **Update `openai-fetch` to 3.3.1 and handle refusals**

This allows us to keep the message types stricter and avoid having to continually check for refusals by parsing all responses from the API and throwing a `RefusalError` if the model sends a message with a refusal.
